### PR TITLE
Using mbstring (improve performance on localhost)

### DIFF
--- a/src/CSSJanus.php
+++ b/src/CSSJanus.php
@@ -258,12 +258,13 @@ class CSSJanus {
 	 * @return string
 	 */
 	private static function fixLeftAndRight($css) {
-		if (extension_loaded('mbstring')){
+		if (extension_loaded('mbstring')) {
       			mb_internal_encoding("UTF-8");
       			mb_regex_encoding("UTF-8");
-      			$css = mb_eregi_replace(trim(rtrim(self::$patterns['left'],'i'),'/'), self::$patterns['tmpToken'], $css);
-      			$css = mb_eregi_replace(trim(rtrim(self::$patterns['right'],'i'),'/'), 'left', $css);
-    		}else{
+      			$css = mb_eregi_replace(trim(rtrim(self::$patterns['left'], 'i'), '/'),
+						self::$patterns['tmpToken'], $css);
+      			$css = mb_eregi_replace(trim(rtrim(self::$patterns['right'], 'i'), '/'), 'left', $css);
+    		} else { 
       			$css = preg_replace(self::$patterns['left'], self::$patterns['tmpToken'], $css);
       			$css = preg_replace(self::$patterns['right'], 'left', $css);
     		}

--- a/src/CSSJanus.php
+++ b/src/CSSJanus.php
@@ -261,11 +261,13 @@ class CSSJanus {
 		if (extension_loaded('mbstring')) {
       			mb_internal_encoding("UTF-8");
       			mb_regex_encoding("UTF-8");
-      			$css = mb_eregi_replace(trim(rtrim(self::$patterns['left'], 'i'), '/'),
-					self::$patterns['tmpToken'], $css
-			);
+      			$css = mb_eregi_replace(
+				trim(rtrim(self::$patterns['left'], 'i'), '/'),
+				self::$patterns['tmpToken'],
+				$css
+				);
       			$css = mb_eregi_replace(trim(rtrim(self::$patterns['right'], 'i'), '/'), 'left', $css);
-	        } else {
+	    } else {
       			$css = preg_replace(self::$patterns['left'], self::$patterns['tmpToken'], $css);
       			$css = preg_replace(self::$patterns['right'], 'left', $css);
     		}

--- a/src/CSSJanus.php
+++ b/src/CSSJanus.php
@@ -262,9 +262,10 @@ class CSSJanus {
       			mb_internal_encoding("UTF-8");
       			mb_regex_encoding("UTF-8");
       			$css = mb_eregi_replace(trim(rtrim(self::$patterns['left'], 'i'), '/'),
-						self::$patterns['tmpToken'], $css);
+					self::$patterns['tmpToken'], $css
+			);
       			$css = mb_eregi_replace(trim(rtrim(self::$patterns['right'], 'i'), '/'), 'left', $css);
-    		} else { 
+	        } else {
       			$css = preg_replace(self::$patterns['left'], self::$patterns['tmpToken'], $css);
       			$css = preg_replace(self::$patterns['right'], 'left', $css);
     		}

--- a/src/CSSJanus.php
+++ b/src/CSSJanus.php
@@ -262,15 +262,15 @@ class CSSJanus {
       			mb_internal_encoding("UTF-8");
       			mb_regex_encoding("UTF-8");
       			$css = mb_eregi_replace(
-				trim(rtrim(self::$patterns['left'], 'i'), '/'),
-				self::$patterns['tmpToken'],
-				$css
+				    trim(rtrim(self::$patterns['left'], 'i'), '/'),
+				    self::$patterns['tmpToken'],
+				    $css
 				);
       			$css = mb_eregi_replace(trim(rtrim(self::$patterns['right'], 'i'), '/'), 'left', $css);
 	    } else {
       			$css = preg_replace(self::$patterns['left'], self::$patterns['tmpToken'], $css);
       			$css = preg_replace(self::$patterns['right'], 'left', $css);
-    		}
+	}
     		$css = str_replace(self::$patterns['tmpToken'], 'right', $css);
     		return $css;
 	}

--- a/src/CSSJanus.php
+++ b/src/CSSJanus.php
@@ -258,11 +258,17 @@ class CSSJanus {
 	 * @return string
 	 */
 	private static function fixLeftAndRight($css) {
-		$css = preg_replace(self::$patterns['left'], self::$patterns['tmpToken'], $css);
-		$css = preg_replace(self::$patterns['right'], 'left', $css);
-		$css = str_replace(self::$patterns['tmpToken'], 'right', $css);
-
-		return $css;
+		if (extension_loaded('mbstring')){
+      			mb_internal_encoding("UTF-8");
+      			mb_regex_encoding("UTF-8");
+      			$css = mb_eregi_replace(trim(rtrim(self::$patterns['left'],'i'),'/'), self::$patterns['tmpToken'], $css);
+      			$css = mb_eregi_replace(trim(rtrim(self::$patterns['right'],'i'),'/'), 'left', $css);
+    		}else{
+      			$css = preg_replace(self::$patterns['left'], self::$patterns['tmpToken'], $css);
+      			$css = preg_replace(self::$patterns['right'], 'left', $css);
+    		}
+    		$css = str_replace(self::$patterns['tmpToken'], 'right', $css);
+    		return $css;
 	}
 
 	/**

--- a/src/CSSJanus.php
+++ b/src/CSSJanus.php
@@ -270,7 +270,7 @@ class CSSJanus {
 	    } else {
       			$css = preg_replace(self::$patterns['left'], self::$patterns['tmpToken'], $css);
       			$css = preg_replace(self::$patterns['right'], 'left', $css);
-	}
+	    }
     		$css = str_replace(self::$patterns['tmpToken'], 'right', $css);
     		return $css;
 	}


### PR DESCRIPTION
When there is a large amount of CSS content, the preg_replace function freezes apache on localhost (Xampp or Wamp)