### PR TITLE
Sync up escaping

### DIFF
--- a/src/CSSJanus.php
+++ b/src/CSSJanus.php
@@ -35,7 +35,7 @@ class CSSJanus {
 	private static $patterns = array(
 		'tmpToken' => '`TMP`',
 		'nonAscii' => '[\200-\377]',
-		'unicode' => '(?:(?:\\[0-9a-f]{1,6})(?:\r\n|\s)?)',
+		'unicode' => '(?:(?:\\\\[0-9a-f]{1,6})(?:\r\n|\s)?)',
 		'num' => '(?:[0-9]*\.[0-9]+|[0-9]+)',
 		'unit' => '(?:em|ex|px|cm|mm|in|pt|pc|deg|rad|grad|ms|s|hz|khz|%)',
 		'body_selector' => 'body\s*{\s*',
@@ -92,7 +92,7 @@ class CSSJanus {
 
 		// @codingStandardsIgnoreStart Generic.Files.LineLength.TooLong
 		$patterns =& self::$patterns;
-		$patterns['escape'] = "(?:{$patterns['unicode']}|\\[^\r\n\f0-9a-f])";
+		$patterns['escape'] = "(?:{$patterns['unicode']}|\\\\[^\\r\\n\f0-9a-f])";
 		$patterns['nmstart'] = "(?:[_a-z]|{$patterns['nonAscii']}|{$patterns['escape']})";
 		$patterns['nmchar'] = "(?:[_a-z0-9-]|{$patterns['nonAscii']}|{$patterns['escape']})";
 		$patterns['ident'] = "-?{$patterns['nmstart']}{$patterns['nmchar']}*";
@@ -100,7 +100,7 @@ class CSSJanus {
 		$patterns['possibly_negative_quantity'] = "((?:-?{$patterns['quantity']})|(?:inherit|auto))";
 		$patterns['color'] = "(#?{$patterns['nmchar']}+|(?:rgba?|hsla?)\([ \d.,%-]+\))";
 		$patterns['url_chars'] = "(?:{$patterns['url_special_chars']}|{$patterns['nonAscii']}|{$patterns['escape']})*";
-		$patterns['lookahead_not_open_brace'] = "(?!({$patterns['nmchar']}|\r?\n|\s|#|\:|\.|\,|\+|>|\(|\)|\[|\]|=|\*=|~=|\^=|'[^']*'])*?{)";
+		$patterns['lookahead_not_open_brace'] = "(?!({$patterns['nmchar']}|\\r?\\n|\s|#|\:|\.|\,|\+|>|\(|\)|\[|\]|=|\*=|~=|\^=|'[^']*'])*?{)";
 		$patterns['lookahead_not_closing_paren'] = "(?!{$patterns['url_chars']}?{$patterns['valid_after_uri_chars']}\))";
 		$patterns['lookahead_for_closing_paren'] = "(?={$patterns['url_chars']}?{$patterns['valid_after_uri_chars']}\))";
 		$patterns['noflip_single'] = "/({$patterns['noflip_annotation']}{$patterns['lookahead_not_open_brace']}[^;}]+;?)/i";


### PR DESCRIPTION
Incorporates https://github.com/cssjanus/cssjanus/commit/d0d6a1ce0c65b1760236e5e91d932097293ffa2b

Splits the escaping changes from https://github.com/cssjanus/php-cssjanus/pull/19 which were already in the upstream cssjanus repo