### PR TITLE
build: Drop PHP 5.5 support and limit HHVM support to 3.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,9 @@ php:
   - "7.1"
   - "7.0"
   - "5.6"
-  - "5.5"
-  # hhvm-3.26 changed its PHP_VERSION to be 7.1.99 instead of 5.6.99
-  # which breaks 'composer install' because HHVM does not support
-  # use of empty property keys, whereas PHP 7
-  # https://github.com/composer/composer/issues/7361
-  - "hhvm-3.24"
-  - "hhvm-3.21"
+  # Only support the HHVM version that MediaWiki supports.
+  # Also, hhvm-3.26 changed its PHP_VERSION from 5.6.99 to 7.1.99 which breaks Composer.
+  # – <https://github.com/composer/composer/issues/7361>
   - "hhvm-3.18"
 install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		}
 	},
 	"require": {
-		"php": ">=5.5.9"
+		"php": ">=5.6.0"
 	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "^0.9.2",


### PR DESCRIPTION
This limits support to PHP versions that are currently supported
or were supported in the last 6 months.

Also remove HHVM versions that aren't supported by Wikimedia
from test matrix to make tests faster and because issues in them
would not be prioritised. The next release will likely drop support
entirely.